### PR TITLE
Added xml:lang tag to title

### DIFF
--- a/data/tei/187.xml
+++ b/data/tei/187.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8662">On the Solitaries
-                    - <foreign>ܥܸܠܬܐ ܕܕܘܒܪ̈ܐ ܕܝܼܚܝܕܝܘܬܐ</foreign></title>
+                    - <foreign xml:lang="syr">ܥܸܠܬܐ ܕܕܘܒܪ̈ܐ ܕܝܼܚܝܕܝܘܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/27.xml
+++ b/data/tei/27.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8529">On the
-                    Divine Revelations to Abraham (Memra 1) - <foreign>ܥܠ ܓܠܝܢ̈ܐ ܐܠܗܝ̈ܐ ܕܗܘܘ ܠܘܬ
+                    Divine Revelations to Abraham (Memra 1) - <foreign xml:lang="syr">ܥܠ ܓܠܝܢ̈ܐ ܐܠܗܝ̈ܐ ܕܗܘܘ ܠܘܬ
                         ܐܒܪܗܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>

--- a/data/tei/28.xml
+++ b/data/tei/28.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8530">On the
-                    Divine Revelations to the Patriarchs and the Prophets (Memra 2) - <foreign>ܥܠ ܓܠܝ̈ܢܐ ܐܠܗ̈ܝܐ ܕܗܘܘ ܠܘܬ ܐܒܗ̈ܬܐ ܘܢܒ̈ܝܐ</foreign></title>
+                    Divine Revelations to the Patriarchs and the Prophets (Memra 2) - <foreign xml:lang="syr">ܥܠ ܓܠܝ̈ܢܐ ܐܠܗ̈ܝܐ ܕܗܘܘ ܠܘܬ ܐܒܗ̈ܬܐ ܘܢܒ̈ܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/29.xml
+++ b/data/tei/29.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8531">On the Revelations
-                    to Abraham (Memra 3) - <foreign>ܥܠ ܓܠܝܢ̈ܐ ܕܠܘܬ ܐܒܪܗܡ</foreign></title>
+                    to Abraham (Memra 3) - <foreign xml:lang="syr">ܥܠ ܓܠܝܢ̈ܐ ܕܠܘܬ ܐܒܪܗܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/30.xml
+++ b/data/tei/30.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8532">On the Birth of
-                    Our Lord (Memra 4) - <foreign>ܥܲܠ ܝܲܠܕܹܗ ܕܡܵܪܢ</foreign></title>
+                    Our Lord (Memra 4) - <foreign xml:lang="syr">ܥܲܠ ܝܲܠܕܹܗ ܕܡܵܪܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/31.xml
+++ b/data/tei/31.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8533">On the Virgin Mary
-                    (Memra 5) - <foreign>ܥܲܠ ܡܵܪܬܿܝ ܡܲܪܝܲܡ</foreign></title>
+                    (Memra 5) - <foreign xml:lang="syr">ܥܲܠ ܡܵܪܬܿܝ ܡܲܪܝܲܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/32.xml
+++ b/data/tei/32.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8534">On Epiphany (Memra
-                    6) - <foreign>ܥܲܠ ܕܸܢܚܵܐ</foreign></title>
+                    6) - <foreign xml:lang="syr">ܥܲܠ ܕܸܢܚܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/33.xml
+++ b/data/tei/33.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8535">On John the
-                    Baptist (Memra 7) - <foreign>ܥܲܠ ܡܵܪܝ ܝܘܿܚܲܢܵܢ ܡܲܥܡܕܵܢ̇ܐ</foreign></title>
+                    Baptist (Memra 7) - <foreign xml:lang="syr">ܥܲܠ ܡܵܪܝ ܝܘܿܚܲܢܵܢ ܡܲܥܡܕܵܢ̇ܐ</foreign></title>
                 <!-- Insert titles and add work # -->
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>

--- a/data/tei/34.xml
+++ b/data/tei/34.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8536">On Peter and Paul
-                    (Memra 8) - <foreign>ܕܕܼܘܼܟܼܪܵܢܵܐ ܕܦܲܛܪܘܿܣ ܘܦܵܘܠܘܿܣ</foreign></title>
+                    (Memra 8) - <foreign xml:lang="syr">ܕܕܼܘܼܟܼܪܵܢܵܐ ܕܦܲܛܪܘܿܣ ܘܦܵܘܠܘܿܣ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/340.xml
+++ b/data/tei/340.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8821">An Admonition -
-                        <foreign>ܕܡܲܪܬ݁ܝܵܢܘܼܬܼܵܐ</foreign></title>
+                        <foreign xml:lang="syr">ܕܡܲܪܬ݁ܝܵܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/341.xml
+++ b/data/tei/341.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8822">On the Descent of
-                    the Highest upon Mount Sinai - <foreign>ܕܥܲܠ ܡܲܚܲܬ݁ܬܹܗ ܕܪܵܡܵܐ ܥܲܠ ܛܘܼܪ
+                    the Highest upon Mount Sinai - <foreign xml:lang="syr">ܕܥܲܠ ܡܲܚܲܬ݁ܬܹܗ ܕܪܵܡܵܐ ܥܲܠ ܛܘܼܪ
                         ܣܝܼܢܲܝ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>

--- a/data/tei/342.xml
+++ b/data/tei/342.xml
@@ -3,7 +3,7 @@
     <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" level="a" ref="http://syriaca.org/work/8823">On the Consecration of the Church and on Moses the Prophet  - <foreign>ܥܲܠ ܩܘܼܕܵܫ ܥܹܕܬܵܐ ܘܥܲܠ ܡܘܼܫܹܐ ܢܒ̣ܝܼܵܐ</foreign></title>
+                <title xml:lang="en" level="a" ref="http://syriaca.org/work/8823">On the Consecration of the Church and on Moses the Prophet  - <foreign xml:lang="syr">ܥܲܠ ܩܘܼܕܵܫ ܥܹܕܬܵܐ ܘܥܲܠ ܡܘܼܫܹܐ ܢܒ̣ܝܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>

--- a/data/tei/343.xml
+++ b/data/tei/343.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8824">On the Brazen
-                    Serpent that Moses Set up in the Wilderness - <foreign>ܥܲܠ ܚܸܘܝܵܐ ܕܲܢܚܵܫܵܐ
+                    Serpent that Moses Set up in the Wilderness - <foreign xml:lang="syr">ܥܲܠ ܚܸܘܝܵܐ ܕܲܢܚܵܫܵܐ
                         ܕܐܲܪܝܼܡ ܡܘܼܫܹܐ ܒܡܲܕܼܒ݁ܪܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>

--- a/data/tei/344.xml
+++ b/data/tei/344.xml
@@ -3,7 +3,7 @@
     <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" level="a" ref="http://syriaca.org/work/8825">On Aaron the Priest - <foreign>ܥܲܠ ܐܲܗܪܘܿܢ ܟܵܗܢܵܐ</foreign></title>
+                <title xml:lang="en" level="a" ref="http://syriaca.org/work/8825">On Aaron the Priest - <foreign xml:lang="syr">ܥܲܠ ܐܲܗܪܘܿܢ ܟܵܗܢܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/345.xml
+++ b/data/tei/345.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8826">On That Star Which
-                    the Magi Saw - <foreign>ܥܲܠ ܟܵܘܟ݁ܒ̣ܵܐ ܗܵܘ̇ ܕܐܸܬܼܚܙܝܼ
+                    the Magi Saw - <foreign xml:lang="syr">ܥܲܠ ܟܵܘܟ݁ܒ̣ܵܐ ܗܵܘ̇ ܕܐܸܬܼܚܙܝܼ
                     ܠܲܡܓ̣ܘܼ̈ܫܹܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>

--- a/data/tei/346.xml
+++ b/data/tei/346.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8827">On the Baptism of
                     the Law and on the Baptism of John and on the Baptism That Our Lord Gave to the
-                    Apostles - <foreign>ܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܼܵܐ ܕܢܵܡܘܿܣܵܐ ܘܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܹܗ ܕܝܘܿܚܲܢܵܢ
+                    Apostles - <foreign xml:lang="syr">ܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܼܵܐ ܕܢܵܡܘܿܣܵܐ ܘܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܹܗ ܕܝܘܿܚܲܢܵܢ
                         ܘܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܼܵܐ ܕܝܲܗ̣̄ܒ̣ ܡܵܪܲܢ ܠܲܫܠܝܼܚܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>

--- a/data/tei/347.xml
+++ b/data/tei/347.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8828">On the Baptism of
-                    our Savior in the Jordan - <foreign>ܥܲܠ ܥܡܵܕܼܗ ܕܦܵܪܘܿܩܲܢ
+                    our Savior in the Jordan - <foreign xml:lang="syr">ܥܲܠ ܥܡܵܕܼܗ ܕܦܵܪܘܿܩܲܢ
                     ܕܲܒ̣ܝܘܿܪܕܢܵܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>

--- a/data/tei/348.xml
+++ b/data/tei/348.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8829">On Holy Baptism -
-                        <foreign>ܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܼܵܐ ܩܲܕܝܼܫܬܵܐ</foreign></title>
+                        <foreign xml:lang="syr">ܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܼܵܐ ܩܲܕܝܼܫܬܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/349.xml
+++ b/data/tei/349.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8830">On the Prayer That
-                    Our Lord Taught to his Disciples: Our Father Which Art in Heaven - <foreign>ܥܲܠ
+                    Our Lord Taught to his Disciples: Our Father Which Art in Heaven - <foreign xml:lang="syr">ܥܲܠ
                         ܨܠܘܿܬܼܵܐ ܕܐܲܠܸܦ̣ ܡܵܪܲܢ ܠܬܲܠܡܝܼܕܼܵܘ̈ܗܝ ܐܲܒ̣ܘܼܢ ܕܒܲܫܡܲܝܵܐ ܢܸܬܼܩܲܕܲܫ
                         ܫܡܵܟ̣</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob

--- a/data/tei/35.xml
+++ b/data/tei/35.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8537">On the Four
-                    Evangelists (Memra 9) - <foreign>ܥܲܠ ܫܠܝܼܚܹ̈ܐ</foreign></title>
+                    Evangelists (Memra 9) - <foreign xml:lang="syr">ܥܲܠ ܫܠܝܼܚܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/350.xml
+++ b/data/tei/350.xml
@@ -3,7 +3,7 @@
     <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" level="a" ref="http://syriaca.org/work/8831">On that Young Man who Said to Our Lord What Should I Do to Inherit Eternal Life - <foreign>ܥܲܠ ܗܵܘ̇ ܥܠܲܝܡܵܐ ܕܐܸܡܲܪ ܠܡܵܪܲܢ ܕܡܵܢܵܐ ܐܸܥܒܸ݁ܕܼ ܕܐܹܪܲܬܼ ܚܲܝܹ̈ܐ ܕܲܠܥܵܠܲܡ</foreign></title>
+                <title xml:lang="en" level="a" ref="http://syriaca.org/work/8831">On that Young Man who Said to Our Lord What Should I Do to Inherit Eternal Life - <foreign xml:lang="syr">ܥܲܠ ܗܵܘ̇ ܥܠܲܝܡܵܐ ܕܐܸܡܲܪ ܠܡܵܪܲܢ ܕܡܵܢܵܐ ܐܸܥܒܸ݁ܕܼ ܕܐܹܪܲܬܼ ܚܲܝܹ̈ܐ ܕܲܠܥܵܠܲܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/351.xml
+++ b/data/tei/351.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8832">On the Prodigal
-                    Son - <foreign>ܥܲܠ ܗܵܘ̇ ܒܪܵܐ ܕܦܲܪܲܚ̣ ܢܸܟ̣ܣܵܘ̈ܗܝ</foreign></title>
+                    Son - <foreign xml:lang="syr">ܥܲܠ ܗܵܘ̇ ܒܪܵܐ ܕܦܲܪܲܚ̣ ܢܸܟ̣ܣܵܘ̈ܗܝ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/352.xml
+++ b/data/tei/352.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8833">On the Pharisee
-                    and the Publican Who Went up to the Temple to Pray - <foreign>ܥܲܠ ܦܪܝܼܫܵܐ
+                    and the Publican Who Went up to the Temple to Pray - <foreign xml:lang="syr">ܥܲܠ ܦܪܝܼܫܵܐ
                         ܘܡܵܟ̣ܣܵܐ ܕܐܸܡܲܪ ܡܵܪܲܢ ܕܲܣܠܸܩ̣ܘ ܠܗܲܝܟ݁ܠܵܐ ܠܲܡܨܲܠܵܝܘܼ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>

--- a/data/tei/353.xml
+++ b/data/tei/353.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8834">On the Parable
                     That Our Lord Spoke about the Laborers Whom the Lord of the Vineyard Hired -
-                        <foreign>ܥܲܠ ܡܲܬܼܠܵܐ ܕܐܸܡܲܪ ܡܵܪܲܢ ܕܦܵܥ̈ܠܹܐ ܕܐܸܓܲܪ ܡܵܪܹܐ
+                        <foreign xml:lang="syr">ܥܲܠ ܡܲܬܼܠܵܐ ܕܐܸܡܲܪ ܡܵܪܲܢ ܕܦܵܥ̈ܠܹܐ ܕܐܸܓܲܪ ܡܵܪܹܐ
                     ܟܲܪܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>

--- a/data/tei/354.xml
+++ b/data/tei/354.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8835">On Zacchaeus the
-                    Publican - <foreign>ܥܲܠ ܙܲܟܲܝ ܡܵܟ̣ܣܵܐ</foreign></title>
+                    Publican - <foreign xml:lang="syr">ܥܲܠ ܙܲܟܲܝ ܡܵܟ̣ܣܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/355.xml
+++ b/data/tei/355.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8836">On the Rich Man
-                    and Lazarus - <foreign>ܲܥܲܠ ܥܲܬ݁ܝܼܪܵܐ ܘܠܵܥܵܙܲܪ</foreign></title>
+                    and Lazarus - <foreign xml:lang="syr">ܲܥܲܠ ܥܲܬ݁ܝܼܪܵܐ ܘܠܵܥܵܙܲܪ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/356.xml
+++ b/data/tei/356.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8837">On the Canaanite Woman  -
-                    <foreign>ܥܲܠ ܟܢܲܥܢܵܝܬܵܐ</foreign></title>
+                    <foreign xml:lang="syr">ܥܲܠ ܟܢܲܥܢܵܝܬܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/357.xml
+++ b/data/tei/357.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8838">On Palm Sunday -
-                        <foreign>ܥܲܠ ܚܲܕܼܒܿܫܲܒܵܐ ܕܐܘܿܫܲܥ̈ܢܹܐ</foreign></title>
+                        <foreign xml:lang="syr">ܥܲܠ ܚܲܕܼܒܿܫܲܒܵܐ ܕܐܘܿܫܲܥ̈ܢܹܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/358.xml
+++ b/data/tei/358.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8839">On Our Lord's Question and on the Revelation That Simon Received from the Father -
-                    <foreign>ܥܲܠ ܫܘܼܐܵܠܹܗ ܕܡܵܪܲܢ ܘܥܲܠ ܓܸܠܝܵܢܵܐ ܕܩܲܒܸܿܠܼ ܫܸܡܥܘܿܢ ܡܼܢ ܐܲܒܼܵܐ</foreign></title>
+                    <foreign xml:lang="syr">ܥܲܠ ܫܘܼܐܵܠܹܗ ܕܡܵܪܲܢ ܘܥܲܠ ܓܸܠܝܵܢܵܐ ܕܩܲܒܸܿܠܼ ܫܸܡܥܘܿܢ ܡܼܢ ܐܲܒܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/359.xml
+++ b/data/tei/359.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8840">On Simon Peter
-                    When Our Lord Said to him, Get Thee Behind Me Satan - <foreign>ܥܲܠ ܫܸܡܥܘܿܢ
+                    When Our Lord Said to him, Get Thee Behind Me Satan - <foreign xml:lang="syr">ܥܲܠ ܫܸܡܥܘܿܢ
                         ܟܹܐܦܵܐ ܟܲܕܼ ܐܸܡܸܿܪ ܠܹܗ ܡܵܪܲܢ ܙܸܠ ܠܵܟܼ ܠܒܸܣܬܲܪܝ ܣܵܛܵܢܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>

--- a/data/tei/36.xml
+++ b/data/tei/36.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8538">On Stephen (Memra
-                    10) - <foreign>ܕܕܼܘܼܟܼܪܵܢܵܐ ܕܡܵܪܝ ܐܸܣܛܲܦܵܢܘܿܣ</foreign></title>
+                    10) - <foreign xml:lang="syr">ܕܕܼܘܼܟܼܪܵܢܵܐ ܕܡܵܪܝ ܐܸܣܛܲܦܵܢܘܿܣ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/360.xml
+++ b/data/tei/360.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8841">On the Denial of Peter -
-                    <foreign>ܥܲܠ ܟܦܘܼܪܝܹܗ ܕܫܸܡܥܘܿܢ</foreign></title>
+                    <foreign xml:lang="syr">ܥܲܠ ܟܦܘܼܪܝܹܗ ܕܫܸܡܥܘܿܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/361.xml
+++ b/data/tei/361.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8842">On the Memorial of
-                    the Departed and on the Eucharistic Bread - <foreign>ܥܠ ܕܗܟܪܢܐ ܕܥܢܝ̈ܕܐ ܘܥܠ
+                    the Departed and on the Eucharistic Bread - <foreign xml:lang="syr">ܥܠ ܕܗܟܪܢܐ ܕܥܢܝ̈ܕܐ ܘܥܠ
                         ܩܨܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>

--- a/data/tei/362.xml
+++ b/data/tei/362.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8843">On the Lenten Fast
-                    I - <foreign>ܥܲܠ ܨܵܘܡܵܐ ܩܲܕܝܼܫܵܐ ܕܐܲܪܒ̇ܥܝܼܢ ܐ</foreign></title>
+                    I - <foreign xml:lang="syr">ܥܲܠ ܨܵܘܡܵܐ ܩܲܕܝܼܫܵܐ ܕܐܲܪܒ̇ܥܝܼܢ ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/363.xml
+++ b/data/tei/363.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8844">On the Lenten Fast
-                    II - <foreign>ܥܲܠ ܨܵܘܡܵܐ ܩܲܕܝܼܫܵܐ ܕܐܲܪܒܿܥܝܼܢ ܒ</foreign></title>
+                    II - <foreign xml:lang="syr">ܥܲܠ ܨܵܘܡܵܐ ܩܲܕܝܼܫܵܐ ܕܐܲܪܒܿܥܝܼܢ ܒ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/364.xml
+++ b/data/tei/364.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8845">On the Lenten Fast III -
-                    <foreign><!-- Insert Syriac title --></foreign></title>
+                    <foreign xml:lang="syr"><!-- Insert Syriac title --></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/365.xml
+++ b/data/tei/365.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8846">On the Love of God and On Perfect Reconciliation -
-                    <foreign>ܥܲܠ ܚܘܼܒܵܐ ܒܪܵܐ ܕܐܲܠܵܗܵܐ ܕܐܸܬܼܵܐ ܒܚܘܼܒܹܗ ܕܲܢܚܲܕܸܬܼ ܟܠ</foreign></title>
+                    <foreign xml:lang="syr">ܥܲܠ ܚܘܼܒܵܐ ܒܪܵܐ ܕܐܲܠܵܗܵܐ ܕܐܸܬܼܵܐ ܒܚܘܼܒܹܗ ܕܲܢܚܲܕܸܬܼ ܟܠ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/366.xml
+++ b/data/tei/366.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8847">On Godly Virginity -
-                    <foreign>ܥܲܠ ܡܲܪܬܝܵܢܘܼܬܼܵܐ</foreign></title>
+                    <foreign xml:lang="syr">ܥܲܠ ܡܲܪܬܝܵܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/367.xml
+++ b/data/tei/367.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8848">On the Power of
-                    Repentance - <foreign>ܥܲܠ ܬܼܝܵܒܼܘܼܬܼܵܐ</foreign></title>
+                    Repentance - <foreign xml:lang="syr">ܥܲܠ ܬܼܝܵܒܼܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/368.xml
+++ b/data/tei/368.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8849">On Repentance and
-                    an Admonition - <foreign>ܥܲܠ ܬܝܵܒܼܘܼܬܼܵܐ ܘܡܲܪܬܿܝܵܢܘܼܬܼܵܐ</foreign></title>
+                    an Admonition - <foreign xml:lang="syr">ܥܲܠ ܬܝܵܒܼܘܼܬܼܵܐ ܘܡܲܪܬܿܝܵܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/37.xml
+++ b/data/tei/37.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8539">On the Three
-                    Doctors (Memra 11) - <foreign>ܥܲܠ ܐܲܒܼܗ̈ܬܼܵܐ ܘܡܲܠܦܵܢܹ̈ܐ
+                    Doctors (Memra 11) - <foreign xml:lang="syr">ܥܲܠ ܐܲܒܼܗ̈ܬܼܵܐ ܘܡܲܠܦܵܢܹ̈ܐ
                     ܝܵܘܢܝܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>

--- a/data/tei/38.xml
+++ b/data/tei/38.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8540">On the Iniquity of
-                    the World (Memra 12) - <foreign>ܥܲܠ ܒܝܼܫܘܼܬܼ ܙܲܒܼܢܵܐ ܘܠܵܚܹܡ
+                    the World (Memra 12) - <foreign xml:lang="syr">ܥܲܠ ܒܝܼܫܘܼܬܼ ܙܲܒܼܢܵܐ ܘܠܵܚܹܡ
                         ܠܒܼܵܥܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>

--- a/data/tei/39.xml
+++ b/data/tei/39.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8541">On Supplication
-                    (Memra 13) - <foreign>ܕܒܼܵܥܘܼܬܼܵܐ ܘܲܕܼܨܵܘܡܵܐ</foreign></title>
+                    (Memra 13) - <foreign xml:lang="syr">ܕܒܼܵܥܘܼܬܼܵܐ ܘܲܕܼܨܵܘܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/40.xml
+++ b/data/tei/40.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8542">On Jonah (Memra
-                    14) - <foreign>ܥܠ ܝܘܢܢ ܢܒܝܐ</foreign></title>
+                    14) - <foreign xml:lang="syr">ܥܠ ܝܘܢܢ ܢܒܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/41.xml
+++ b/data/tei/41.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8543">On Reproof (Memra
-                    15) - <foreign>ܥܲܠ ܡܲܟܿܣܵܢܘܼܬܼܵܐ</foreign></title>
+                    15) - <foreign xml:lang="syr">ܥܲܠ ܡܲܟܿܣܵܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/42.xml
+++ b/data/tei/42.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8544">On Human Nature
-                    (Memra 16) - <foreign>ܥܠ ܟܝܢܐ ܐܢܫܝܐ</foreign></title>
+                    (Memra 16) - <foreign xml:lang="syr">ܥܠ ܟܝܢܐ ܐܢܫܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/43.xml
+++ b/data/tei/43.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8545">For Any Saints Day
-                    (Memra 17) - <foreign>ܡܐܡܪܐ ܕܚܕ ܦܪܨܘܦܐ</foreign></title>
+                    (Memra 17) - <foreign xml:lang="syr">ܡܐܡܪܐ ܕܚܕ ܦܪܨܘܦܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/44.xml
+++ b/data/tei/44.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8546">On the Departed
-                    and the Resurrection (Memra 18) - <foreign>ܡܐܡܪܐ ܕܥܠ ܥܢܝܕ̈ܐ ܘܥܠ ܚܝܬ
+                    and the Resurrection (Memra 18) - <foreign xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܥܢܝܕ̈ܐ ܘܥܠ ܚܝܬ
                         ܡܝ̈ܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>

--- a/data/tei/45.xml
+++ b/data/tei/45.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8547">On Works (Memra
-                    19) - <foreign>ܥܲܠ ܓܡܝܼܪܘܼܬ ܕܘܼܒܵܪܹ̈ܐ</foreign></title>
+                    19) - <foreign xml:lang="syr">ܥܲܠ ܓܡܝܼܪܘܼܬ ܕܘܼܒܵܪܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/46.xml
+++ b/data/tei/46.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8548">On Lent I (Memra
-                    20) - <foreign>ܕܚܲܕܼܒܿܫܲܒܵܐ ܩܲܕܼܡܵܝܵܐ ܕܨܵܘܡܵܐ</foreign></title>
+                    20) - <foreign xml:lang="syr">ܕܚܲܕܼܒܿܫܲܒܵܐ ܩܲܕܼܡܵܝܵܐ ܕܨܵܘܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/47.xml
+++ b/data/tei/47.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8549">On the Temptation
-                    of Christ (Memra 21) - <foreign>ܥܲܠ ܕܪ̈ܵܘܗܝ ܕܡܪܢ</foreign></title>
+                    of Christ (Memra 21) - <foreign xml:lang="syr">ܥܲܠ ܕܪ̈ܵܘܗܝ ܕܡܪܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/48.xml
+++ b/data/tei/48.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8550">On the Temptation
-                    of Christ (Memra 22) - <foreign>ܥܲܠ ܕܪ̈ܵܘܗܝ ܕܡܵܪܲܢ</foreign></title>
+                    of Christ (Memra 22) - <foreign xml:lang="syr">ܥܲܠ ܕܪ̈ܵܘܗܝ ܕܡܵܪܲܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/49.xml
+++ b/data/tei/49.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/">On Lent III (Memra 23)
-                    - <foreign>ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܲܬܼܠܵܬܼܵܐ ܕܨܵܘܡܵܐ</foreign></title>
+                    - <foreign xml:lang="syr">ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܲܬܼܠܵܬܼܵܐ ܕܨܵܘܡܵܐ</foreign></title>
                 <!-- Insert titles and add work # -->
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>

--- a/data/tei/50.xml
+++ b/data/tei/50.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8552">On Lent IV (Memra
-                    24) - <foreign>ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܐܲܪܒܿܥܵܐ ܕܨܵܘܡܵܐ</foreign></title>
+                    24) - <foreign xml:lang="syr">ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܐܲܪܒܿܥܵܐ ܕܨܵܘܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/51.xml
+++ b/data/tei/51.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8553">On Reproof (Memra
-                    25) - <foreign>ܥܲܠ ܡܸܣܟܹܿܢܘܼܬܼܵܐ</foreign></title>
+                    25) - <foreign xml:lang="syr">ܥܲܠ ܡܸܣܟܹܿܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/52.xml
+++ b/data/tei/52.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8554">On Lent V (Memra
-                    26) - <foreign>ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܚܲܡܫܵܐ ܕܨܵܡܵܐ</foreign></title>
+                    26) - <foreign xml:lang="syr">ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܚܲܡܫܵܐ ܕܨܵܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/53.xml
+++ b/data/tei/53.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8555">On the Parable of
-                    the Ten Virgins (Memra 27) - <foreign>ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܸܫܬܵܐ
+                    the Ten Virgins (Memra 27) - <foreign xml:lang="syr">ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܸܫܬܵܐ
                     ܕܨܵܘܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>

--- a/data/tei/54.xml
+++ b/data/tei/54.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8556">On the Raising of
-                    Lazarus (Memra 28) - <foreign>ܥܲܠ ܩܝܵܡܬܹܗ ܕܠܵܠܙܲܪ</foreign></title>
+                    Lazarus (Memra 28) - <foreign xml:lang="syr">ܥܲܠ ܩܝܵܡܬܹܗ ܕܠܵܠܙܲܪ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/55.xml
+++ b/data/tei/55.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8557">On Palm Sunday
-                    (Memra 29) - <foreign>ܐܚܪܸܢܐ ܕܥܸܐܕܐ ܕܐܘܼܫܥܵܢܐ</foreign></title>
+                    (Memra 29) - <foreign xml:lang="syr">ܐܚܪܸܢܐ ܕܥܸܐܕܐ ܕܐܘܼܫܥܵܢܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>

--- a/data/tei/56.xml
+++ b/data/tei/56.xml
@@ -4,7 +4,7 @@
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8558">On Palm Sunday
-                    (Memra 30) - <foreign>ܕܐܘܫܥ̈ܢܐ</foreign></title>
+                    (Memra 30) - <foreign xml:lang="syr">ܕܐܘܫܥ̈ܢܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
                 <title level="s">The Oxford-BYU Syriac Corpus</title>


### PR DESCRIPTION
Specified <foreign> tag with xml:lang=“syr” attribute for all texts
missing it across the corpus