### PR TITLE
Corpus Name change

### DIFF
--- a/data/tei/1.xml
+++ b/data/tei/1.xml
@@ -8,7 +8,7 @@
                     ܕܗܝܡܢܘܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/1</idno>
                 <availability>
                     <p/>
@@ -99,11 +99,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/10.xml
+++ b/data/tei/10.xml
@@ -8,7 +8,7 @@
                 </title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/10</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/100.xml
+++ b/data/tei/100.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Matthew the Evangelist</author>
                 <!-- Need person URI for Matthew? -->
                 <sponsor>University of Oxford</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/100</idno>
                 <availability>
                     <p/>
@@ -113,11 +113,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/101.xml
+++ b/data/tei/101.xml
@@ -7,7 +7,7 @@
                     73) - <foreign xml:lang="syr">ܥܲܠ ܫܸܡܫܘܿܢ ܓܲܢ̄ܒܵܪܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/101</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/102.xml
+++ b/data/tei/102.xml
@@ -7,7 +7,7 @@
                     (Memra 74) - <foreign xml:lang="syr">ܥܠ ܕܘܼܝܼܕ ܘܫܐܘܿ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/102</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/103.xml
+++ b/data/tei/103.xml
@@ -8,7 +8,7 @@
                     ܕܝܢܘܼܬܹܗ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/103</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/104.xml
+++ b/data/tei/104.xml
@@ -8,7 +8,7 @@
                     ܘܕܐܠܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/104</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/105.xml
+++ b/data/tei/105.xml
@@ -8,7 +8,7 @@
                         ܘܡܝܼܫܵܐܹܝܠ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/105</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/106.xml
+++ b/data/tei/106.xml
@@ -8,7 +8,7 @@
                         ܕܟܼܵܗܢܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/106</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/107.xml
+++ b/data/tei/107.xml
@@ -7,7 +7,7 @@
                     79) - <foreign xml:lang="syr">ܥܲܠ ܡܲܟܿܣܵܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/107</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/108.xml
+++ b/data/tei/108.xml
@@ -8,7 +8,7 @@
                         ܘܥܲܒܠ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/108</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/109.xml
+++ b/data/tei/109.xml
@@ -8,7 +8,7 @@
                         ܒܲܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/109</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/11.xml
+++ b/data/tei/11.xml
@@ -7,7 +7,7 @@
                     On Circumcision - <foreign xml:lang="syr">ܬܚܘܝܬܐ ܕܓܙܘܪܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/11</idno>
                 <availability>
                     <p/>
@@ -83,11 +83,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/110.xml
+++ b/data/tei/110.xml
@@ -7,7 +7,7 @@
                     2) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܪܶܝܢ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/110</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/111.xml
+++ b/data/tei/111.xml
@@ -7,7 +7,7 @@
                     3) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܠܳܬ݂ܳܐ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/111</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/112.xml
+++ b/data/tei/112.xml
@@ -7,7 +7,7 @@
                     4) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܐܪܒܥܳܐ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/112</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/113.xml
+++ b/data/tei/113.xml
@@ -7,7 +7,7 @@
                     5) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܚܰܡܫܳܐ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/113</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/114.xml
+++ b/data/tei/114.xml
@@ -7,7 +7,7 @@
                     6) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܶܫܬܳܐ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/114</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/115.xml
+++ b/data/tei/115.xml
@@ -7,7 +7,7 @@
                     7) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܫܰܒܥܳܐ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/115</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/116.xml
+++ b/data/tei/116.xml
@@ -7,7 +7,7 @@
                     8) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܡܳܢܝܳܐ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/116</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/117.xml
+++ b/data/tei/117.xml
@@ -7,7 +7,7 @@
                     9) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܬܶܫܥܳܐ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/117</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/118.xml
+++ b/data/tei/118.xml
@@ -7,7 +7,7 @@
                     10) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܳܐ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/118</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/119.xml
+++ b/data/tei/119.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Mark the Evangelist</author>
                 <!-- Need person URI for Matthew? -->
                 <sponsor>University of Oxford</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/119</idno>
                 <availability>
                     <p/>
@@ -102,11 +102,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/12.xml
+++ b/data/tei/12.xml
@@ -7,7 +7,7 @@
                     On Passover - <foreign xml:lang="syr">ܬܚܘܝܬܐ ܕܦܨܚܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/12</idno>
                 <availability>
                     <p/>
@@ -83,11 +83,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/120.xml
+++ b/data/tei/120.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Luke the Evangelist</author>
                 <!-- Need person URI for Matthew? -->
                 <sponsor>University of Oxford</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/120</idno>
                 <availability>
                     <p/>
@@ -102,11 +102,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/121.xml
+++ b/data/tei/121.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/1826">John the Evangelist</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/121</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/122.xml
+++ b/data/tei/122.xml
@@ -9,7 +9,7 @@
                     Catholic Epitles (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Luke the Evangelist</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/122</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/123.xml
+++ b/data/tei/123.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/123</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/124.xml
+++ b/data/tei/124.xml
@@ -10,7 +10,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/124</idno>
                 <availability>
                     <p/>
@@ -102,11 +102,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/126.xml
+++ b/data/tei/126.xml
@@ -10,7 +10,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/125</idno>
                 <availability>
                     <p/>
@@ -102,11 +102,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/127.xml
+++ b/data/tei/127.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/127</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/128.xml
+++ b/data/tei/128.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/128</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/129.xml
+++ b/data/tei/129.xml
@@ -10,7 +10,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/129</idno>
                 <availability>
                     <p/>
@@ -102,11 +102,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/13.xml
+++ b/data/tei/13.xml
@@ -7,7 +7,7 @@
                     On the Sabbath - <foreign xml:lang="syr">ܬܚܘܝܬܐ ܕܫܒܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/13</idno>
                 <availability>
                     <p/>
@@ -83,11 +83,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/130.xml
+++ b/data/tei/130.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/130</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/131.xml
+++ b/data/tei/131.xml
@@ -10,7 +10,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/131</idno>
                 <availability>
                     <p/>
@@ -102,11 +102,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/132.xml
+++ b/data/tei/132.xml
@@ -10,7 +10,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/132</idno>
                 <availability>
                     <p/>
@@ -102,11 +102,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/133.xml
+++ b/data/tei/133.xml
@@ -10,7 +10,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/133</idno>
                 <availability>
                     <p/>
@@ -102,11 +102,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/134.xml
+++ b/data/tei/134.xml
@@ -10,7 +10,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/134</idno>
                 <availability>
                     <p/>
@@ -102,11 +102,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/135.xml
+++ b/data/tei/135.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/135</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/136.xml
+++ b/data/tei/136.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Paul the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/136</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/137.xml
+++ b/data/tei/137.xml
@@ -9,7 +9,7 @@
                     (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/137</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/138.xml
+++ b/data/tei/138.xml
@@ -11,7 +11,7 @@
                     Catholic Epitles (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>James the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -66,7 +66,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/138</idno>
                 <availability>
                     <p/>
@@ -103,11 +103,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/139.xml
+++ b/data/tei/139.xml
@@ -11,7 +11,7 @@
                     Catholic Epitles (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Peter the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -66,7 +66,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/139</idno>
                 <availability>
                     <p/>
@@ -103,11 +103,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/14.xml
+++ b/data/tei/14.xml
@@ -7,7 +7,7 @@
                     A Petition - <foreign xml:lang="syr">ܬܚܘܝܬܐ ܕܦܝܣܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/14</idno>
                 <availability>
                     <p/>
@@ -83,11 +83,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/140.xml
+++ b/data/tei/140.xml
@@ -11,7 +11,7 @@
                     Catholic Epitles (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Peter the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -66,7 +66,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/140</idno>
                 <availability>
                     <p/>
@@ -103,11 +103,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/141.xml
+++ b/data/tei/141.xml
@@ -11,7 +11,7 @@
                     Catholic Epitles (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>John the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -66,7 +66,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/141</idno>
                 <availability>
                     <p/>
@@ -103,11 +103,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/142.xml
+++ b/data/tei/142.xml
@@ -11,7 +11,7 @@
                     Catholic Epitles (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>John the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -66,7 +66,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/142</idno>
                 <availability>
                     <p/>
@@ -103,11 +103,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/143.xml
+++ b/data/tei/143.xml
@@ -11,7 +11,7 @@
                     Catholic Epitles (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>John the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -66,7 +66,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/143</idno>
                 <availability>
                     <p/>
@@ -103,11 +103,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/144.xml
+++ b/data/tei/144.xml
@@ -11,7 +11,7 @@
                     Catholic Epitles (Peshitta Version)</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Jude the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -66,7 +66,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/144</idno>
                 <availability>
                     <p/>
@@ -103,11 +103,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/145.xml
+++ b/data/tei/145.xml
@@ -7,7 +7,7 @@
                     Version) - <foreign xml:lang="syr">ܓܠܝܢܐ ܕܝܘܚܢܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/70">The Peshitta New
                     Testament</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>John the Apostle</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -62,7 +62,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/145</idno>
                 <availability>
                     <p/>
@@ -99,11 +99,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/146.xml
+++ b/data/tei/146.xml
@@ -7,7 +7,7 @@
                     Ode 3</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/146</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/147.xml
+++ b/data/tei/147.xml
@@ -7,7 +7,7 @@
                     Ode 4</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/147</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/148.xml
+++ b/data/tei/148.xml
@@ -7,7 +7,7 @@
                     Ode 5</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/148</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/149.xml
+++ b/data/tei/149.xml
@@ -7,7 +7,7 @@
                     Ode 6</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/149</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/15.xml
+++ b/data/tei/15.xml
@@ -8,7 +8,7 @@
                         ܡܐ̈ܟܠܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/15</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/150.xml
+++ b/data/tei/150.xml
@@ -7,7 +7,7 @@
                     Ode 7</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/150</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/151.xml
+++ b/data/tei/151.xml
@@ -7,7 +7,7 @@
                     Ode 8</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/151</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/152.xml
+++ b/data/tei/152.xml
@@ -7,7 +7,7 @@
                     Ode 9</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/152</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/153.xml
+++ b/data/tei/153.xml
@@ -7,7 +7,7 @@
                     Ode 10</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/153</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/154.xml
+++ b/data/tei/154.xml
@@ -7,7 +7,7 @@
                     Ode 11</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/154</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/155.xml
+++ b/data/tei/155.xml
@@ -7,7 +7,7 @@
                     Ode 12</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/155</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/156.xml
+++ b/data/tei/156.xml
@@ -7,7 +7,7 @@
                     Ode 13</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/156</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/157.xml
+++ b/data/tei/157.xml
@@ -7,7 +7,7 @@
                     Ode 14</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/157</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/158.xml
+++ b/data/tei/158.xml
@@ -7,7 +7,7 @@
                     Ode 15</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/158</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/159.xml
+++ b/data/tei/159.xml
@@ -7,7 +7,7 @@
                     Ode 16</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/159</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/16.xml
+++ b/data/tei/16.xml
@@ -8,7 +8,7 @@
                         ܕܥܠ ܥܡܡ̈ܐ ܕܗܘܘ ܚܠܦ ܥܡܐ </foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/16</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/160.xml
+++ b/data/tei/160.xml
@@ -7,7 +7,7 @@
                     Ode 17</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/160</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/161.xml
+++ b/data/tei/161.xml
@@ -7,7 +7,7 @@
                     Ode 18</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/161</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/162.xml
+++ b/data/tei/162.xml
@@ -7,7 +7,7 @@
                     Ode 19</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/162</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/163.xml
+++ b/data/tei/163.xml
@@ -7,7 +7,7 @@
                     Ode 20</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/163</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/164.xml
+++ b/data/tei/164.xml
@@ -7,7 +7,7 @@
                     Ode 21</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/164</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/165.xml
+++ b/data/tei/165.xml
@@ -7,7 +7,7 @@
                     Ode 22</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/165</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/166.xml
+++ b/data/tei/166.xml
@@ -7,7 +7,7 @@
                     Ode 23</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/166</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/167.xml
+++ b/data/tei/167.xml
@@ -7,7 +7,7 @@
                     Ode 24</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/167</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/168.xml
+++ b/data/tei/168.xml
@@ -7,7 +7,7 @@
                     Ode 25</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/168</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/169.xml
+++ b/data/tei/169.xml
@@ -7,7 +7,7 @@
                     Ode 26</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/169</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/17.xml
+++ b/data/tei/17.xml
@@ -8,7 +8,7 @@
                         ܥܠ ܡܫܝܚܐ܂ ܕܒܪܗ ܗܘ ܕܐܠܗܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/17</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/170.xml
+++ b/data/tei/170.xml
@@ -7,7 +7,7 @@
                     Ode 27</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/170</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/171.xml
+++ b/data/tei/171.xml
@@ -7,7 +7,7 @@
                     Ode 28</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/171</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/172.xml
+++ b/data/tei/172.xml
@@ -7,7 +7,7 @@
                     Ode 29</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/172</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/173.xml
+++ b/data/tei/173.xml
@@ -7,7 +7,7 @@
                     Ode 30</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/173</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/174.xml
+++ b/data/tei/174.xml
@@ -7,7 +7,7 @@
                     Ode 31</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/174</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/175.xml
+++ b/data/tei/175.xml
@@ -7,7 +7,7 @@
                     Ode 32</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/175</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/176.xml
+++ b/data/tei/176.xml
@@ -7,7 +7,7 @@
                     Ode 33</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/176</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/177.xml
+++ b/data/tei/177.xml
@@ -7,7 +7,7 @@
                     Ode 34</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/177</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/178.xml
+++ b/data/tei/178.xml
@@ -7,7 +7,7 @@
                     Ode 35</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/178</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/179.xml
+++ b/data/tei/179.xml
@@ -7,7 +7,7 @@
                     Ode 36</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/179</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/18.xml
+++ b/data/tei/18.xml
@@ -8,7 +8,7 @@
                         ܕܠܘܩܒܠ ܝܗܘ̈ܕܝܐ܂ ܘܥܠ ܒܬܘܠܘܬܐ ܘܩܕܝܫܘܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/18</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/180.xml
+++ b/data/tei/180.xml
@@ -7,7 +7,7 @@
                     Ode 37</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/180</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/181.xml
+++ b/data/tei/181.xml
@@ -7,7 +7,7 @@
                     Ode 38</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/181</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/182.xml
+++ b/data/tei/182.xml
@@ -7,7 +7,7 @@
                     Ode 39</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/182</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/183.xml
+++ b/data/tei/183.xml
@@ -7,7 +7,7 @@
                     Ode 40</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/183</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/184.xml
+++ b/data/tei/184.xml
@@ -7,7 +7,7 @@
                     Ode 41</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/184</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/185.xml
+++ b/data/tei/185.xml
@@ -7,7 +7,7 @@
                     Ode 42</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8620">The Odes of
                     Solomon</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/185</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/186.xml
+++ b/data/tei/186.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8661">Book of the Laws of the Countries - <foreign xml:lang="syr">ܟܬܒܐ ܕܢܡ̈ܘܣܐ
                     ܕܐܬܪ̈ܘܬܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3">Bardaisan</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                                             <placeName>Jean and Alexander Heard Library System, Vanderbilt
                             University, Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/186</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/187.xml
+++ b/data/tei/187.xml
@@ -7,7 +7,7 @@
                     - <foreign xml:lang="syr">ܥܸܠܬܐ ܕܕܘܒܪ̈ܐ ܕܝܼܚܝܕܝܘܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/321">Abraham of Nathpar</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/187</idno>
                 <availability>
                     <p/>
@@ -89,11 +89,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/188.xml
+++ b/data/tei/188.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8663">Memra One - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܩܰܕܡܳܝܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/188</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/189.xml
+++ b/data/tei/189.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8664">Memra Two: About Those Who Want to Become Perfect - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܪܶܝܢ ܕܥܰܠ ܐܰܝܠܶܝܢ ܕܨܳܒܶܝܢ ܕܢܶܬܓܰܡܪܽܘܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/189</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/19.xml
+++ b/data/tei/19.xml
@@ -9,7 +9,7 @@
                         ܠܡܬܟܢܫܘ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/19</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/190.xml
+++ b/data/tei/190.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8665">Memra Three: The Physical And the Spiritual Ministry - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܠܳܬܳܐ ܕܥܰܠ ܬܶܫܡܶܫܬܳܐ ܦܰܓܪܳܢܳܝܬܳܐ ܘܪܽܘܚܳܢܳܝܬܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/190</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/191.xml
+++ b/data/tei/191.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8666">Memra Four: On the Vegetables for the Sick - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܐܪܒܥܳܐ ܕܥܰܠ ܝܰܪܩܳܐ ܕܰܟܪ̈ܺܝܗܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/191</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/192.xml
+++ b/data/tei/192.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8667">Memra Five: On the Milk of the Children - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܚܰܡܫܳܐ ܕܥܰܠ ܚܰܠܒܳܐ ܕܝܰܠ̈ܽܘܕܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/192</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/193.xml
+++ b/data/tei/193.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8668">Memra Six: On Those Who Are Made Perfect and Continue to Grow - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܶܫܬܳܐ ܕܥܰܠ ܐ̱ܢܳܫ ܕܡܶܬܓܡܰܪ ܘܝܳܪܶܒ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/193</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/194.xml
+++ b/data/tei/194.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8669">Memra Seven: On the Commandments of the Upright - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܫܰܒܥܳܐ ܕܥܰܠ ܦܽܘܩܕ̈ܳܢܶܐ ܕܟܺܐܢ̈ܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/194</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/195.xml
+++ b/data/tei/195.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8670">Memra Eight: On One Who Gives All He Has to Feed the Poor - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܡܳܢܝܳܐ ܕܥܰܠ ܡܰܢ ܕܡܰܘܟܶܠ ܟܽܠ ܕܰܩܢܶܐ ܠܡܶܣ̈ܟܺܢܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/195</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/196.xml
+++ b/data/tei/196.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8671">Memra Nine: On Uprightness and the Love of the Upright and the Prophets - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܬܶܫܥܳܐ ܥܰܠ ܟܺܐܢܽܘܬܳܐ ܘܥܰܠ ܚܽܘܒܳܐ ܕܟܺܐܢ̈ܶܐ ܘܕܰܢܒܺܝ̈ܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/196</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/197.xml
+++ b/data/tei/197.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8672">Memra Ten - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/197</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/198.xml
+++ b/data/tei/198.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8673">Memra Eleven - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܚܕܰܥܣܰܪ ܕܥܰܠ ܡܰܫܡܰܥܬܳܐ ܕܰܟܬܳܒ̈ܶܐ ܘܶܐܡܰܬܝ ܕܡܶܬܩܪܶܐ ܢܳܡܽܘܣܳܐ ܩܕܳܡܰܝܢ.</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/198</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/199.xml
+++ b/data/tei/199.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8674">Memra Twelve: On the Hidden and Public Ministry of the Church - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܪ̈ܶܥܣܰܪ ܕܥܰܠ ܬܶܫܡܶܫܬܳܐ ܕܥܽܕ̱ܬܳܐ ܟܣܺܝܬܳܐ ܘܰܓܠܺܝܬܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/199</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/2.xml
+++ b/data/tei/2.xml
@@ -8,7 +8,7 @@
                     ܕܚܘܒܐ܂</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/2</idno>
                 <availability>
                     <p/>
@@ -100,11 +100,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/20.xml
+++ b/data/tei/20.xml
@@ -8,7 +8,7 @@
                         ܕܡ̈ܣܟܢܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/20</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/200.xml
+++ b/data/tei/200.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8675">Memra Thirteen: By the Same Author on the Ways of the Upright - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܠܳܬܰܥܣܰܪ ܕܺܝܠܶܗ ܕܥܰܠ ܕܽܘܒܳܪ̈ܶܐ ܕܟܺܐܢ̈ܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/200</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/201.xml
+++ b/data/tei/201.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8676">Memra Fourteen: On the Upright and the Perfect - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܐܪܒܰܥܬܰܥܣܰܪ ܕܥܰܠ ܟܺܐܢ̈ܶܐ ܘܥܰܠ ܓܡܺܝܪ̈ܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/201</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/202.xml
+++ b/data/tei/202.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8677">Memra Fifteen: On Adam's Marital Desire - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܚܰܡܶܫܬܰܥܣܰܪ ܕܥܰܠ ܡܰܪܕܺܝܬܳܐ ܕܙܽܘܘܳܓܳܐ ܕܰܗܘܳܬ ܒܳܐܕܳܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/202</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/203.xml
+++ b/data/tei/203.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8678">Memra Sixteen: On How a Person May Surpass the Major Commandments - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܫܶܬܬܰܥܣܰܪ ܕܥܰܠ ܕܰܐܝܟܰܢ ܝܳܪܶܒ ܐ̱ܢܳܫ ܡܶܢ ܦܽܘܩ̈ܕܳܢܶܐ ܪܰܘܪ̈ܒܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/203</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/204.xml
+++ b/data/tei/204.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8679">Memra Seventeen: On the Sufferings of Our Lord Who Became Through Them an Example for Us - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܫܒܰܥܬܰܥܣܰܪ ܕܥܰܠ ܚܰܫܰܘ̈ܗ̱ܝ ܕܡܳܪܰܢ ܕܰܗܘܳܐ ܠܰܢ ܒܗܽܘܢ ܚܰܘܪܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/204</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/205.xml
+++ b/data/tei/205.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8680">Memra Eighteen: On the Tears of Prayer - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܡܳܢܬܰܥܣܰܪ ܕܥܰܠ ܕܶܡ̈ܥܶܐ ܕܰܨܠܽܘܬܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/205</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/206.xml
+++ b/data/tei/206.xml
@@ -8,7 +8,7 @@
                         ܕܰܬܫܰܥܣܰܪ ܕܥܰܠ ܦܽܘܪܫܳܢܳܐ ܕܽܐܘܪܚܳܐ ܕܰܓܡܺܝܪܽܘܬܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of
                     Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/206</idno>
                 <availability>
                     <p/>
@@ -98,11 +98,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/207.xml
+++ b/data/tei/207.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8682">Memra Twenty: On the Difficult Steps that are on the Road of the City of Our Lord - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪ̈ܺܝܢ ܡܰܣ̈ܩܳܬܳܐ ܩܰܫܝ̈ܳܬܳܐ ܕܺܐܝܬ ܒܽܐܘܪܚܳܐ ܕܰܡܕܺܝܢ̱ܬܶܗ ܕܡܳܪܰܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/207</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/208.xml
+++ b/data/tei/208.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8683">Memra Twenty-one: On the Tree of Adam - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪ̈ܺܝܢ ܘܚܰܕ ܕܥܰܠ ܐܺܝܠܳܢܳܐ ܕܳܐܕܳܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/208</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/209.xml
+++ b/data/tei/209.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8684">Memra Twenty-two: On the Judgments That Do Not Save Those Who Observe Them - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܺܝܢ ܘܰܬܪ̈ܶܝܢ ܕܥܰܠ ܕܺܝܢ̈ܶܐ ܕܠܳܐ ܚܳܐܶܝܢ ܒܗܽܘܢ ܥܳܒ̈ܽܘܕܰܝܗܽܘܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/209</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/21.xml
+++ b/data/tei/21.xml
@@ -7,7 +7,7 @@
                     On Persecution - <foreign xml:lang="syr">ܬܚܘܝܬܐ ܕܪܕܘܦܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/21</idno>
                 <availability>
                     <p/>
@@ -83,11 +83,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/210.xml
+++ b/data/tei/210.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8685">Memra Twenty-three: On Satan and Pharoah and the Israelites - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܺܝܢ ܘܰܬܠܳܬܳܐ ܕܥܰܠ ܤܳܛܳܢܳܐ ܘܥܰܠ ܦܶܪܥܽܘܢ ܒܢܰܝ̈ ܐܺܝܣܪܳܐܶܝܠ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                                             <placeName>Jean and Alexander Heard Library System, Vanderbilt
                             University, Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/210</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/211.xml
+++ b/data/tei/211.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8686">Memra Twenty-four: On Repentance - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܺܝܢ ܘܰܐܪܒܥܳܐ ܕܥܰܠ ܬܝܳܒܽܘܬܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/211</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/212.xml
+++ b/data/tei/212.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8687">Memra Twenty-five: On the Voice of God and of Satan - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܺܝܢ ܘܚܰܡܫܳܐ ܕܥܰܠ ܒܰܪ̱ܬ ܩܳܠܳܐ ܕܰܐܠܳܗܳܐ ܘܰܕܤܳܛܳܢܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/212</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/213.xml
+++ b/data/tei/213.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8688">Memra Twenty-six: On the Second Law That the Lord Established From Adam - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܺܝܢ ܘܶܫܬܳܐ ܥܰܠ ܢܳܡܺܘܣܳܐ ܕܰܬܪܶܝܢ ܕܣܳܡ ܡܳܪܝܳܐ ܠܳܐܕܳܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/213</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/214.xml
+++ b/data/tei/214.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8689">Memra Twenty-seven: About the History of the Thief Who is Saved - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܺܝܢ ܘܫܰܒܥܳܐ ܕܥܰܠ ܫܰܪܒܳܐ ܕܓܰܝ̈ܣܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/214</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/215.xml
+++ b/data/tei/215.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8690">Memra Twenty-eight: On the Fact That the Human Soul is Not Identical With the Blood - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܺܝܢ ܘܰܬܡܳܢܝܳܐ ܕܥܰܠ ܢܰܦܫܳܐ ܕܒܰܪܢܳܫܳܐ ܕܠܳܐ ܗܘܳܬ ܕܡܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/215</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/216.xml
+++ b/data/tei/216.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8691">Memra Twenty-nine: On the Discipline of the Body - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܥܶܣܪܺܝܢ ܘܬܶܫܥܳܐ ܕܥܰܠ ܟܽܘܒܳܫ ܦܰܓܪܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/216</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/217.xml
+++ b/data/tei/217.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8692">Memra Thirty: On the Commandments of Faith and the Love of the Solitaries - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܕܰܬܠܳܬܺܝܢ. ܕܥܰܠ ܦܽܘܩܕ̈ܳܢܶܐ ܕܗܰܝܡܳܢܽܘܬܳܐ ܘܰܕܚܽܘܒܳܐ ܕܺܝܚܺܝ̈ܕܳܝܶܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/217</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/218.xml
+++ b/data/tei/218.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8694">Book of Steps Preface - <foreign xml:lang="syr">ܡܰܡܠ̱ܠܳܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8693">The Book of Steps</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                             University, Nashville, Tennessee, USA</placeName>
 
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/218</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/219.xml
+++ b/data/tei/219.xml
@@ -7,7 +7,7 @@
                     Recognitions: Recognition 1</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8695">The
                     Pseudo-Clementine Recognitions and Homilies</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3585">Pseudo-Clement</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/219</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/22.xml
+++ b/data/tei/22.xml
@@ -9,7 +9,7 @@
                 </title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/22</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/220.xml
+++ b/data/tei/220.xml
@@ -7,7 +7,7 @@
                     Recognitions: Recognition 2</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8695">The
                     Pseudo-Clementine Recognitions and Homilies</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3585">Pseudo-Clement</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/220</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/221.xml
+++ b/data/tei/221.xml
@@ -7,7 +7,7 @@
                     Recognitions: Recognition 3</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8695">The
                     Pseudo-Clementine Recognitions and Homilies</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3585">Pseudo-Clement</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/221</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/222.xml
+++ b/data/tei/222.xml
@@ -7,7 +7,7 @@
                     Recognitions: Recognition 4</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8695">The
                     Pseudo-Clementine Recognitions and Homilies</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3585">Pseudo-Clement</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/222</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/223.xml
+++ b/data/tei/223.xml
@@ -7,7 +7,7 @@
                     Homilies: Homily 10</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8695">The
                     Pseudo-Clementine Recognitions and Homilies</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3585">Pseudo-Clement</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/223</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/224.xml
+++ b/data/tei/224.xml
@@ -7,7 +7,7 @@
                     Homilies: Homily 11</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8695">The
                     Pseudo-Clementine Recognitions and Homilies</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3585">Pseudo-Clement</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/224</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/225.xml
+++ b/data/tei/225.xml
@@ -7,7 +7,7 @@
                     Homilies: Homily 12</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8695">The
                     Pseudo-Clementine Recognitions and Homilies</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3585">Pseudo-Clement</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/225</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/226.xml
+++ b/data/tei/226.xml
@@ -7,7 +7,7 @@
                     Homilies: Homily 13</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8695">The
                     Pseudo-Clementine Recognitions and Homilies</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3585">Pseudo-Clement</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/226</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/227.xml
+++ b/data/tei/227.xml
@@ -7,7 +7,7 @@
                     Homilies: Homily 14</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8695">The
                     Pseudo-Clementine Recognitions and Homilies</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/3585">Pseudo-Clement</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/227</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/228.xml
+++ b/data/tei/228.xml
@@ -7,7 +7,7 @@
                     on Genesis - <foreign xml:lang="syr">ܣܦܪܐ ܕܒܪܝܬܐ ܣܘܥܪܢܐܝܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/228</idno>
                 <availability>
                     <p/>
@@ -93,11 +93,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/229.xml
+++ b/data/tei/229.xml
@@ -8,7 +8,7 @@
                         ܕܡܿܟܢܼܫ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/229</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/23.xml
+++ b/data/tei/23.xml
@@ -9,7 +9,7 @@
                 </title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -65,7 +65,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/23</idno>
                 <availability>
                     <p/>
@@ -101,11 +101,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/230.xml
+++ b/data/tei/230.xml
@@ -8,7 +8,7 @@
                         ܕܟܗ̈ܢܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/230</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/231.xml
+++ b/data/tei/231.xml
@@ -8,7 +8,7 @@
                         ܣܘܥܪܢܐܝܬ </foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/231</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/232.xml
+++ b/data/tei/232.xml
@@ -8,7 +8,7 @@
                         ܕܡܬܩܪܐ ܬܢܝܢ ܢܡܘܿܣܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/232</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/233.xml
+++ b/data/tei/233.xml
@@ -8,7 +8,7 @@
                     ܒܙܥܘܪ̈ܝܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/233</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/234.xml
+++ b/data/tei/234.xml
@@ -8,7 +8,7 @@
                     ܒܪܢܘܿܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/234</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/235.xml
+++ b/data/tei/235.xml
@@ -8,7 +8,7 @@
                         ܠܝܬ ܗܼܘܐ ܒܝܣܪܐܝܠ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/235</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/236.xml
+++ b/data/tei/236.xml
@@ -8,7 +8,7 @@
                     ܢܒܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/236</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/237.xml
+++ b/data/tei/237.xml
@@ -7,7 +7,7 @@
                     on Kings - <foreign xml:lang="syr">ܦܘܼܫܩܐ ܣܘܼܥܪܢܝܐ ܕܣܦܪ ܡܠ̈ܟܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/237</idno>
                 <availability>
                     <p/>
@@ -93,11 +93,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/238.xml
+++ b/data/tei/238.xml
@@ -7,7 +7,7 @@
                     <foreign xml:lang="syr">ܦܘܼܫܩܐ ܣܘܥܪܢܝܐ ܕܟܬܒܐ ܕܡܙܡܘܪ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/238</idno>
                 <availability>
                     <p/>
@@ -93,11 +93,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/239.xml
+++ b/data/tei/239.xml
@@ -8,7 +8,7 @@
                         ܡܢܬܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/239</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/24.xml
+++ b/data/tei/24.xml
@@ -7,7 +7,7 @@
                     Letter</title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/24</idno>
                 <availability>
                     <p/>
@@ -83,11 +83,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/240.xml
+++ b/data/tei/240.xml
@@ -7,7 +7,7 @@
                         <foreign xml:lang="syr">ܦܘܼܫܩܐ ܣܘܼܥܪܢܝܐ ܕܟܬܒܐ ܕܩܘܼܗܠܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/240</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/241.xml
+++ b/data/tei/241.xml
@@ -8,7 +8,7 @@
                         ܫܐܪ̈ܝܼܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/241</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/242.xml
+++ b/data/tei/242.xml
@@ -8,7 +8,7 @@
                     ܢܒܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/242</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/243.xml
+++ b/data/tei/243.xml
@@ -8,7 +8,7 @@
                         ܕܐܪܡܝܐ ܢܒܝܐ ܣܘܼܥܪܢܝܐ ܘܪܘܼܚܢܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/243</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/244.xml
+++ b/data/tei/244.xml
@@ -8,7 +8,7 @@
                     ܢܒܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/244</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/245.xml
+++ b/data/tei/245.xml
@@ -8,7 +8,7 @@
                         ܣܘܼܥܪܢܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/245</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/246.xml
+++ b/data/tei/246.xml
@@ -7,7 +7,7 @@
                     on Hosea - <foreign xml:lang="syr">ܦܘܼܫܩܐ ܣܘܼܥܪܢܝܐ ܕܗܘܼܫܥ ܢܒܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/246</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/247.xml
+++ b/data/tei/247.xml
@@ -8,7 +8,7 @@
                         ܣܘܼܥܪܢܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/247</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/248.xml
+++ b/data/tei/248.xml
@@ -7,7 +7,7 @@
                     on Amos - <foreign xml:lang="syr">ܦܘܼܫܩܐ ܕܥܡܘܿܣ ܣܘܼܥܪܢܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/248</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/249.xml
+++ b/data/tei/249.xml
@@ -8,7 +8,7 @@
                         ܣܘܼܥܪܢܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/249</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/250.xml
+++ b/data/tei/250.xml
@@ -8,7 +8,7 @@
                     ܣܘܼܥܪܢܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/250</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/251.xml
+++ b/data/tei/251.xml
@@ -8,7 +8,7 @@
                         ܡܝܼܟܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/251</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/252.xml
+++ b/data/tei/252.xml
@@ -7,7 +7,7 @@
                         <foreign xml:lang="syr">ܢܘܼܗܪܐ ܕܢܚܘܡ ܢܒܝܐ ܣܘܼܥܪܢܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/252</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/253.xml
+++ b/data/tei/253.xml
@@ -8,7 +8,7 @@
                     ܣܘܼܥܪܢܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/253</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/254.xml
+++ b/data/tei/254.xml
@@ -8,7 +8,7 @@
                     ܢܒܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/254</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/255.xml
+++ b/data/tei/255.xml
@@ -8,7 +8,7 @@
                     ܕܚܓܝ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/255</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/256.xml
+++ b/data/tei/256.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8734">Literal Commentary on Zechariah - <foreign xml:lang="syr">ܦܘܼܫܩܐ ܕܙܟܪܝܐ ܢܒܝܐ ܣܘܼܥܪܢܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -55,7 +55,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt
                         University, Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/256</idno>
                 <availability>
                     <p/>
@@ -81,11 +81,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/257.xml
+++ b/data/tei/257.xml
@@ -8,7 +8,7 @@
                     ܣܘܼܥܪܢܐܝܼܬ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/257</idno>
                 <availability>
                     <p/>
@@ -85,11 +85,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/258.xml
+++ b/data/tei/258.xml
@@ -7,7 +7,7 @@
                     Sira - <foreign xml:lang="syr">ܦܘܼܫܩܐ ܕܟܬܒܐ ܕܒܪ ܐܣܝܼܪܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8705">Old Testament
                     Commentaries of Dionysius bar Salibi</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/212">Dionysius bar Salibi</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/258</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/26.xml
+++ b/data/tei/26.xml
@@ -7,7 +7,7 @@
                     1) - <foreign xml:lang="syr">ܡܺܐܡܪܳܐ ܩܰܕܡܳܝܳܐ ܕܥܰܠ ܝܰܘܣܶܦ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8527">Memre on
                     Joseph</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/26</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/27.xml
+++ b/data/tei/27.xml
@@ -8,7 +8,7 @@
                         ܐܒܪܗܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                         <placeName>Jean and Alexander Heard Library System, Vanderbilt
                             University, Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/27</idno>
                 <availability>
                     <p/>
@@ -100,11 +100,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/28.xml
+++ b/data/tei/28.xml
@@ -7,7 +7,7 @@
                     Divine Revelations to the Patriarchs and the Prophets (Memra 2) - <foreign xml:lang="syr">ܥܠ ܓܠܝ̈ܢܐ ܐܠܗ̈ܝܐ ܕܗܘܘ ܠܘܬ ܐܒܗ̈ܬܐ ܘܢܒ̈ܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                             <placeName>Jean and Alexander Heard Library System, Vanderbilt
                             University, Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/28</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/29.xml
+++ b/data/tei/29.xml
@@ -7,7 +7,7 @@
                     to Abraham (Memra 3) - <foreign xml:lang="syr">ܥܠ ܓܠܝܢ̈ܐ ܕܠܘܬ ܐܒܪܗܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/29</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/3.xml
+++ b/data/tei/3.xml
@@ -7,7 +7,7 @@
                     On Fasting - <foreign xml:lang="syr">ܬܚܘܝܬܐ ܕܨܘܡܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/3</idno>
                 <availability>
                     <p/>
@@ -83,11 +83,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/30.xml
+++ b/data/tei/30.xml
@@ -7,7 +7,7 @@
                     Our Lord (Memra 4) - <foreign xml:lang="syr">ܥܲܠ ܝܲܠܕܹܗ ܕܡܵܪܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/30</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/31.xml
+++ b/data/tei/31.xml
@@ -7,7 +7,7 @@
                     (Memra 5) - <foreign xml:lang="syr">ܥܲܠ ܡܵܪܬܿܝ ܡܲܪܝܲܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/31</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/32.xml
+++ b/data/tei/32.xml
@@ -7,7 +7,7 @@
                     6) - <foreign xml:lang="syr">ܥܲܠ ܕܸܢܚܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/32</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/33.xml
+++ b/data/tei/33.xml
@@ -8,7 +8,7 @@
                 <!-- Insert titles and add work # -->
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/33</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/332.xml
+++ b/data/tei/332.xml
@@ -8,7 +8,7 @@
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8811">The Apocryphal
                     Acts of the Apostles - <foreign xml:lang="syr">ܬܫ̈ܥܝܬܐ ܕܫ̈ܠܝܚܐ
                     ܩܕ̈ܝܫܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/2123">Judas Thomas</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/332</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/333.xml
+++ b/data/tei/333.xml
@@ -8,7 +8,7 @@
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8811">The Apocryphal
                     Acts of the Apostles - <foreign xml:lang="syr">ܬܫ̈ܥܝܬܐ ܕܫ̈ܠܝܚܐ
                     ܩܕ̈ܝܫܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/333</idno>
                 <availability>
                     <p/>
@@ -98,11 +98,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/334.xml
+++ b/data/tei/334.xml
@@ -9,7 +9,7 @@
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8811">The Apocryphal
                     Acts of the Apostles - <foreign xml:lang="syr">ܬܫ̈ܥܝܬܐ ܕܫ̈ܠܝܚܐ
                     ܩܕ̈ܝܫܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/334</idno>
                 <availability>
                     <p/>
@@ -98,11 +98,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/335.xml
+++ b/data/tei/335.xml
@@ -9,7 +9,7 @@
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8811">The Apocryphal
                     Acts of the Apostles - <foreign xml:lang="syr">ܬܫ̈ܥܝܬܐ ܕܫ̈ܠܝܚܐ
                     ܩܕ̈ܝܫܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/335</idno>
                 <availability>
                     <p/>
@@ -99,11 +99,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/336.xml
+++ b/data/tei/336.xml
@@ -7,7 +7,7 @@
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8811">The Apocryphal
                     Acts of the Apostles - <foreign xml:lang="syr">ܬܫ̈ܥܝܬܐ ܕܫ̈ܠܝܚܐ
                     ܩܕ̈ܝܫܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/336</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/337.xml
+++ b/data/tei/337.xml
@@ -9,7 +9,7 @@
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8811">The Apocryphal
                     Acts of the Apostles - <foreign xml:lang="syr">ܬܫ̈ܥܝܬܐ ܕܫ̈ܠܝܚܐ
                     ܩܕ̈ܝܫܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/337</idno>
                 <availability>
                     <p/>
@@ -98,11 +98,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/338.xml
+++ b/data/tei/338.xml
@@ -7,7 +7,7 @@
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8811">The Apocryphal
                     Acts of the Apostles - <foreign xml:lang="syr">ܬܫ̈ܥܝܬܐ ܕܫ̈ܠܝܚܐ
                     ܩܕ̈ܝܫܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/338</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/339.xml
+++ b/data/tei/339.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8819">Dialogue on the
                     Soul - <foreign xml:lang="syr">ܢܝ̈ܫܐ ܐܚܪ̈ܢܐ ܥܠ ܢܦܫܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/827">John the Solitary</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/339</idno>
                 <availability>
                     <p/>
@@ -95,7 +95,7 @@
                     of Oxford and Brigham Young University in collaboration with Vanderbilt
                     University and the Initiative for Digital Humanities, Media, and Culture at
                     Texas A&amp;M University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/34.xml
+++ b/data/tei/34.xml
@@ -7,7 +7,7 @@
                     (Memra 8) - <foreign xml:lang="syr">ܕܕܼܘܼܟܼܪܵܢܵܐ ܕܦܲܛܪܘܿܣ ܘܦܵܘܠܘܿܣ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/34</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/340.xml
+++ b/data/tei/340.xml
@@ -7,7 +7,7 @@
                         <foreign xml:lang="syr">ܕܡܲܪܬ݁ܝܵܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/340</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/341.xml
+++ b/data/tei/341.xml
@@ -8,7 +8,7 @@
                         ܣܝܼܢܲܝ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/341</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/342.xml
+++ b/data/tei/342.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8823">On the Consecration of the Church and on Moses the Prophet  - <foreign xml:lang="syr">ܥܲܠ ܩܘܼܕܵܫ ܥܹܕܬܵܐ ܘܥܲܠ ܡܘܼܫܹܐ ܢܒ̣ܝܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/342</idno>
                 <availability>
                     <p/>
@@ -93,11 +93,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/343.xml
+++ b/data/tei/343.xml
@@ -8,7 +8,7 @@
                         ܕܐܲܪܝܼܡ ܡܘܼܫܹܐ ܒܡܲܕܼܒ݁ܪܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/343</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/344.xml
+++ b/data/tei/344.xml
@@ -6,7 +6,7 @@
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8825">On Aaron the Priest - <foreign xml:lang="syr">ܥܲܠ ܐܲܗܪܘܿܢ ܟܵܗܢܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/344</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/345.xml
+++ b/data/tei/345.xml
@@ -8,7 +8,7 @@
                     ܠܲܡܓ̣ܘܼ̈ܫܹܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/345</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/346.xml
+++ b/data/tei/346.xml
@@ -9,7 +9,7 @@
                         ܘܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܼܵܐ ܕܝܲܗ̣̄ܒ̣ ܡܵܪܲܢ ܠܲܫܠܝܼܚܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/346</idno>
                 <availability>
                     <p/>
@@ -98,11 +98,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/347.xml
+++ b/data/tei/347.xml
@@ -8,7 +8,7 @@
                     ܕܲܒ̣ܝܘܿܪܕܢܵܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/347</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/348.xml
+++ b/data/tei/348.xml
@@ -7,7 +7,7 @@
                         <foreign xml:lang="syr">ܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܼܵܐ ܩܲܕܝܼܫܬܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/348</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/349.xml
+++ b/data/tei/349.xml
@@ -9,7 +9,7 @@
                         ܫܡܵܟ̣</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/349</idno>
                 <availability>
                     <p/>
@@ -98,11 +98,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/35.xml
+++ b/data/tei/35.xml
@@ -7,7 +7,7 @@
                     Evangelists (Memra 9) - <foreign xml:lang="syr">ܥܲܠ ܫܠܝܼܚܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/35</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/350.xml
+++ b/data/tei/350.xml
@@ -6,7 +6,7 @@
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8831">On that Young Man who Said to Our Lord What Should I Do to Inherit Eternal Life - <foreign xml:lang="syr">ܥܲܠ ܗܵܘ̇ ܥܠܲܝܡܵܐ ܕܐܸܡܲܪ ܠܡܵܪܲܢ ܕܡܵܢܵܐ ܐܸܥܒܸ݁ܕܼ ܕܐܹܪܲܬܼ ܚܲܝܹ̈ܐ ܕܲܠܥܵܠܲܡ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/350</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/351.xml
+++ b/data/tei/351.xml
@@ -7,7 +7,7 @@
                     Son - <foreign xml:lang="syr">ܥܲܠ ܗܵܘ̇ ܒܪܵܐ ܕܦܲܪܲܚ̣ ܢܸܟ̣ܣܵܘ̈ܗܝ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/351</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/352.xml
+++ b/data/tei/352.xml
@@ -8,7 +8,7 @@
                         ܘܡܵܟ̣ܣܵܐ ܕܐܸܡܲܪ ܡܵܪܲܢ ܕܲܣܠܸܩ̣ܘ ܠܗܲܝܟ݁ܠܵܐ ܠܲܡܨܲܠܵܝܘܼ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/352</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/353.xml
+++ b/data/tei/353.xml
@@ -9,7 +9,7 @@
                     ܟܲܪܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/353</idno>
                 <availability>
                     <p/>
@@ -98,11 +98,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/354.xml
+++ b/data/tei/354.xml
@@ -7,7 +7,7 @@
                     Publican - <foreign xml:lang="syr">ܥܲܠ ܙܲܟܲܝ ܡܵܟ̣ܣܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/354</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/355.xml
+++ b/data/tei/355.xml
@@ -7,7 +7,7 @@
                     and Lazarus - <foreign xml:lang="syr">ܲܥܲܠ ܥܲܬ݁ܝܼܪܵܐ ܘܠܵܥܵܙܲܪ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/355</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/356.xml
+++ b/data/tei/356.xml
@@ -7,7 +7,7 @@
                     <foreign xml:lang="syr">ܥܲܠ ܟܢܲܥܢܵܝܬܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/356</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/357.xml
+++ b/data/tei/357.xml
@@ -7,7 +7,7 @@
                         <foreign xml:lang="syr">ܥܲܠ ܚܲܕܼܒܿܫܲܒܵܐ ܕܐܘܿܫܲܥ̈ܢܹܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/357</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/358.xml
+++ b/data/tei/358.xml
@@ -7,7 +7,7 @@
                     <foreign xml:lang="syr">ܥܲܠ ܫܘܼܐܵܠܹܗ ܕܡܵܪܲܢ ܘܥܲܠ ܓܸܠܝܵܢܵܐ ܕܩܲܒܸܿܠܼ ܫܸܡܥܘܿܢ ܡܼܢ ܐܲܒܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/358</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/359.xml
+++ b/data/tei/359.xml
@@ -8,7 +8,7 @@
                         ܟܹܐܦܵܐ ܟܲܕܼ ܐܸܡܸܿܪ ܠܹܗ ܡܵܪܲܢ ܙܸܠ ܠܵܟܼ ܠܒܸܣܬܲܪܝ ܣܵܛܵܢܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/359</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/36.xml
+++ b/data/tei/36.xml
@@ -7,7 +7,7 @@
                     10) - <foreign xml:lang="syr">ܕܕܼܘܼܟܼܪܵܢܵܐ ܕܡܵܪܝ ܐܸܣܛܲܦܵܢܘܿܣ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/36</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/360.xml
+++ b/data/tei/360.xml
@@ -7,7 +7,7 @@
                     <foreign xml:lang="syr">ܥܲܠ ܟܦܘܼܪܝܹܗ ܕܫܸܡܥܘܿܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/360</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/361.xml
+++ b/data/tei/361.xml
@@ -8,7 +8,7 @@
                         ܩܨܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/361</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/362.xml
+++ b/data/tei/362.xml
@@ -7,7 +7,7 @@
                     I - <foreign xml:lang="syr">ܥܲܠ ܨܵܘܡܵܐ ܩܲܕܝܼܫܵܐ ܕܐܲܪܒ̇ܥܝܼܢ ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/362</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/363.xml
+++ b/data/tei/363.xml
@@ -7,7 +7,7 @@
                     II - <foreign xml:lang="syr">ܥܲܠ ܨܵܘܡܵܐ ܩܲܕܝܼܫܵܐ ܕܐܲܪܒܿܥܝܼܢ ܒ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/363</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/364.xml
+++ b/data/tei/364.xml
@@ -7,7 +7,7 @@
                     <foreign xml:lang="syr"><!-- Insert Syriac title --></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/364</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/365.xml
+++ b/data/tei/365.xml
@@ -7,7 +7,7 @@
                     <foreign xml:lang="syr">ܥܲܠ ܚܘܼܒܵܐ ܒܪܵܐ ܕܐܲܠܵܗܵܐ ܕܐܸܬܼܵܐ ܒܚܘܼܒܹܗ ܕܲܢܚܲܕܸܬܼ ܟܠ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/365</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/366.xml
+++ b/data/tei/366.xml
@@ -7,7 +7,7 @@
                     <foreign xml:lang="syr">ܥܲܠ ܡܲܪܬܝܵܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/366</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/367.xml
+++ b/data/tei/367.xml
@@ -7,7 +7,7 @@
                     Repentance - <foreign xml:lang="syr">ܥܲܠ ܬܼܝܵܒܼܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/367</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/368.xml
+++ b/data/tei/368.xml
@@ -7,7 +7,7 @@
                     an Admonition - <foreign xml:lang="syr">ܥܲܠ ܬܝܵܒܼܘܼܬܼܵܐ ܘܡܲܪܬܿܝܵܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8820">The Memre of Jacob
                     of Serugh</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/42">Jacob of Serugh</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/368</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/37.xml
+++ b/data/tei/37.xml
@@ -8,7 +8,7 @@
                     ܝܵܘܢܝܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/37</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/372.xml
+++ b/data/tei/372.xml
@@ -6,7 +6,7 @@
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8853">Exhortation of the
                     Apostle Peter - <foreign xml:lang="syr">ܡܡܠܠܐ ܕܛܘܒܢܐ ܦܬܪܘܣ
                         ܫܠܝܚܐ ܕܥܠ ܡܪܬܝܢܘܬܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/372</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/373.xml
+++ b/data/tei/373.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8854">Ecclesiastical
                     History - <foreign xml:lang="syr">ܟܬܒܐ ܕܐܩܠܣܝܣܛܝܩܝ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/239">Gregorius bar Hebraeus</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/373</idno>
                 <availability>
                     <p/>
@@ -99,11 +99,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/374.xml
+++ b/data/tei/374.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8856" n="1">Discourse 1: Prologue - <foreign xml:lang="syr">ܡܺܐܡܪܐ ܩܰܕܡܳܝܐ ܥܶܠܬܐ ܕܟܽܠܳܗ̇ ܦܶܢܩܺܝܬܐ ܗܳܕܶܐ ܒܛܰܝܒܽܘܬܐ  ܕܡܳܪܰܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/374</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/375.xml
+++ b/data/tei/375.xml
@@ -8,7 +8,7 @@
                         ܩܰܕܡܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of
                     Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/375</idno>
                 <availability>
                     <p/>
@@ -103,11 +103,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/376.xml
+++ b/data/tei/376.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8858" n="3">Discourse 3: On Faith - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/376</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/377.xml
+++ b/data/tei/377.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8859" n="4">Discourse 4: On Faith and Simplicity - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/377</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/378.xml
+++ b/data/tei/378.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8860" n="5">Discourse 5: On Simplicity - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/378</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/379.xml
+++ b/data/tei/379.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8861" n="6">Discourse 6: On the Fear of God - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/379</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/38.xml
+++ b/data/tei/38.xml
@@ -8,7 +8,7 @@
                         ܠܒܼܵܥܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/38</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/380.xml
+++ b/data/tei/380.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8862" n="7">Discourse 7: On the Fear of Death - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/380</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/381.xml
+++ b/data/tei/381.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8863" n="8">Discourse 8: On Poverty - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/381</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/382.xml
+++ b/data/tei/382.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8864" n="9">Discourse 9: On Poverty - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/382</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/383.xml
+++ b/data/tei/383.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8865" n="10">Discourse 10: On the Lust of the Belly - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/383</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/384.xml
+++ b/data/tei/384.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8866" n="11">Discourse 11: On Abstinence - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/384</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/385.xml
+++ b/data/tei/385.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8867" n="12">Discourse 12: On Fornication - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/385</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/386.xml
+++ b/data/tei/386.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="a" ref="http://syriaca.org/work/8868" n="13">Discourse 13: On Fornication - <foreign xml:lang="syr"></foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8855">The Discourses of Philoxenos</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/44">Philoxenos of Mabbug</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -56,7 +56,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/386</idno>
                 <availability>
                     <p/>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/39.xml
+++ b/data/tei/39.xml
@@ -7,7 +7,7 @@
                     (Memra 13) - <foreign xml:lang="syr">ܕܒܼܵܥܘܼܬܼܵܐ ܘܲܕܼܨܵܘܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/39</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/4.xml
+++ b/data/tei/4.xml
@@ -8,7 +8,7 @@
                 </title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/4</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/40.xml
+++ b/data/tei/40.xml
@@ -7,7 +7,7 @@
                     14) - <foreign xml:lang="syr">ܥܠ ܝܘܢܢ ܢܒܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/40</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/41.xml
+++ b/data/tei/41.xml
@@ -7,7 +7,7 @@
                     15) - <foreign xml:lang="syr">ܥܲܠ ܡܲܟܿܣܵܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/41</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/42.xml
+++ b/data/tei/42.xml
@@ -7,7 +7,7 @@
                     (Memra 16) - <foreign xml:lang="syr">ܥܠ ܟܝܢܐ ܐܢܫܝܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/42</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/43.xml
+++ b/data/tei/43.xml
@@ -7,7 +7,7 @@
                     (Memra 17) - <foreign xml:lang="syr">ܡܐܡܪܐ ܕܚܕ ܦܪܨܘܦܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/43</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/44.xml
+++ b/data/tei/44.xml
@@ -8,7 +8,7 @@
                         ܡܝ̈ܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/44</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/45.xml
+++ b/data/tei/45.xml
@@ -7,7 +7,7 @@
                     19) - <foreign xml:lang="syr">ܥܲܠ ܓܡܝܼܪܘܼܬ ܕܘܼܒܵܪܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/45</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/46.xml
+++ b/data/tei/46.xml
@@ -7,7 +7,7 @@
                     20) - <foreign xml:lang="syr">ܕܚܲܕܼܒܿܫܲܒܵܐ ܩܲܕܼܡܵܝܵܐ ܕܨܵܘܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/46</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/47.xml
+++ b/data/tei/47.xml
@@ -7,7 +7,7 @@
                     of Christ (Memra 21) - <foreign xml:lang="syr">ܥܲܠ ܕܪ̈ܵܘܗܝ ܕܡܪܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/47</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/48.xml
+++ b/data/tei/48.xml
@@ -7,7 +7,7 @@
                     of Christ (Memra 22) - <foreign xml:lang="syr">ܥܲܠ ܕܪ̈ܵܘܗܝ ܕܡܵܪܲܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/48</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/49.xml
+++ b/data/tei/49.xml
@@ -8,7 +8,7 @@
                 <!-- Insert titles and add work # -->
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/49</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/5.xml
+++ b/data/tei/5.xml
@@ -7,7 +7,7 @@
                     On Wars - <foreign xml:lang="syr">ܬܚܘܝܬܐ܂ ܕܩܪ̈ܒܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/5</idno>
                 <availability>
                     <p/>
@@ -83,11 +83,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/50.xml
+++ b/data/tei/50.xml
@@ -7,7 +7,7 @@
                     24) - <foreign xml:lang="syr">ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܐܲܪܒܿܥܵܐ ܕܨܵܘܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/50</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/51.xml
+++ b/data/tei/51.xml
@@ -7,7 +7,7 @@
                     25) - <foreign xml:lang="syr">ܥܲܠ ܡܸܣܟܹܿܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/51</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/52.xml
+++ b/data/tei/52.xml
@@ -7,7 +7,7 @@
                     26) - <foreign xml:lang="syr">ܕܚܲܕܼܒܿܫܲܒܵܐ ܕܚܲܡܫܵܐ ܕܨܵܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                                             <placeName>Jean and Alexander Heard Library System, Vanderbilt
                             University, Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/52</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/53.xml
+++ b/data/tei/53.xml
@@ -8,7 +8,7 @@
                     ܕܨܵܘܡܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/53</idno>
                 <availability>
                     <p/>
@@ -93,11 +93,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/54.xml
+++ b/data/tei/54.xml
@@ -7,7 +7,7 @@
                     Lazarus (Memra 28) - <foreign xml:lang="syr">ܥܲܠ ܩܝܵܡܬܹܗ ܕܠܵܠܙܲܪ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/54</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/55.xml
+++ b/data/tei/55.xml
@@ -7,7 +7,7 @@
                     (Memra 29) - <foreign xml:lang="syr">ܐܚܪܸܢܐ ܕܥܸܐܕܐ ܕܐܘܼܫܥܵܢܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/55</idno>
                 <!-- Add corpus # -->
                 <availability>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/56.xml
+++ b/data/tei/56.xml
@@ -7,7 +7,7 @@
                     (Memra 30) - <foreign xml:lang="syr">ܕܐܘܫܥ̈ܢܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/56</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/57.xml
+++ b/data/tei/57.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8559">Chronicle of
                     Edessa - <foreign xml:lang="syr">ܬܫ̈ܥܝܬܐ ܕܣܘܥܪ̈ܢܐ</foreign></title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author>Anonymous</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -57,7 +57,7 @@
                                             <placeName>Jean and Alexander Heard Library System, Vanderbilt
                             University, Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/57</idno>
                 <availability>
                     <p/>
@@ -98,11 +98,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/58.xml
+++ b/data/tei/58.xml
@@ -7,7 +7,7 @@
                     (Memra 31) - <foreign xml:lang="syr">ܠܘܼܩܒܲܠ ܝܗ̄ܘܼܕܼܵܝܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/58</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/59.xml
+++ b/data/tei/59.xml
@@ -7,7 +7,7 @@
                     Woman (Memra 32) - <foreign xml:lang="syr">ܕܟܢܥܢܝܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/59</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/6.xml
+++ b/data/tei/6.xml
@@ -8,7 +8,7 @@
                 </title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/6</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/60.xml
+++ b/data/tei/60.xml
@@ -7,7 +7,7 @@
                     Son (Memra 33) - <foreign xml:lang="syr">ܕܥܲܠ ܒܪܵܐ ܐܣܵܘܿܛܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/60</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/61.xml
+++ b/data/tei/61.xml
@@ -7,7 +7,7 @@
                     (Memra 34) - <foreign xml:lang="syr">ܕܚܲܡܫܵܒܿܫܲܒܵܐ ܕܦܸܨܚܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/61</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/62.xml
+++ b/data/tei/62.xml
@@ -7,7 +7,7 @@
                     (Memra 35) - <foreign xml:lang="syr">ܥܲܠ ܦܘܼܫܵܩ ܐ̄ܪ̈ܵܙܹܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/62</idno>
                 <availability>
                     <p/>
@@ -94,11 +94,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/63.xml
+++ b/data/tei/63.xml
@@ -7,7 +7,7 @@
                     (Memra 36) - <foreign xml:lang="syr">ܡܲܪܒܲܥܪܘܿܒܼܬܵܐ ܕܚܲܫܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/63</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/64.xml
+++ b/data/tei/64.xml
@@ -7,7 +7,7 @@
                     Thief (Memra 37) - <foreign xml:lang="syr">ܥܲܠ ܓܲܝܵܣܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/64</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/65.xml
+++ b/data/tei/65.xml
@@ -8,7 +8,7 @@
                         ܡܲܥܡܘܿܕܼܝܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/65</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/66.xml
+++ b/data/tei/66.xml
@@ -7,7 +7,7 @@
                     39) - <foreign xml:lang="syr">ܥܲܠ ܡܲܥܡܘܿܕܼܝܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/66</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/67.xml
+++ b/data/tei/67.xml
@@ -9,7 +9,7 @@
                 <!-- Insert titles and add work # -->
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/67</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/68.xml
+++ b/data/tei/68.xml
@@ -7,7 +7,7 @@
                     (Memra 41) - <foreign xml:lang="syr">ܕܲܥܪܘܼܒܼܬܵܐ ܕܡܵܘܕܿܝܵܢܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/68</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/69.xml
+++ b/data/tei/69.xml
@@ -7,7 +7,7 @@
                     (Memra 42) - <foreign xml:lang="syr">ܥܲܠ ܣܵܗ̈ܕܹܿܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/61</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/7.xml
+++ b/data/tei/7.xml
@@ -8,7 +8,7 @@
                 </title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/7</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/70.xml
+++ b/data/tei/70.xml
@@ -7,7 +7,7 @@
                     (Memra 43) - <foreign xml:lang="syr">ܥܲܠ ܣܵܗ̈ܕܹܿܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/70</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/71.xml
+++ b/data/tei/71.xml
@@ -8,7 +8,7 @@
                         ܕܲܒܼܪܝܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/71</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/72.xml
+++ b/data/tei/72.xml
@@ -7,7 +7,7 @@
                     (Memra 45) - <foreign xml:lang="syr">ܥܲܠ ܣܘܼܠܵܩܹܗ ܕܡܵܪܲܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/72</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/73.xml
+++ b/data/tei/73.xml
@@ -8,7 +8,7 @@
                     ܕܦܲܢܛܹܩܘܼܣܛܹܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/73</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/74.xml
+++ b/data/tei/74.xml
@@ -8,7 +8,7 @@
                         ܠܟܲܪܡܹܗ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/74</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/75.xml
+++ b/data/tei/75.xml
@@ -8,7 +8,7 @@
                         ܘܠܵܥܵܙܵܪ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/75</idno>
                 <!-- Add corpus # -->
                 <availability>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/76.xml
+++ b/data/tei/76.xml
@@ -8,7 +8,7 @@
                         ܘܚܵܘܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/76</idno>
                 <!-- Add corpus # -->
                 <availability>
@@ -97,11 +97,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/77.xml
+++ b/data/tei/77.xml
@@ -7,7 +7,7 @@
                     50) - <foreign xml:lang="syr">ܥܲܠ ܡܲܟܼܝܼܟܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/77</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/78.xml
+++ b/data/tei/78.xml
@@ -8,7 +8,7 @@
                     ܕܐܲܢܛܝܼܟܿܪܸܣܛܘܿܣ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/78</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/79.xml
+++ b/data/tei/79.xml
@@ -7,7 +7,7 @@
                     Coming (Memra 52) - <foreign xml:lang="syr">ܥܲܠ ܓܠܝܵܢܹܗ ܕܡܵܪܲܢ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/79</idno>
                 <!-- Add corpus # -->
                 <availability>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/8.xml
+++ b/data/tei/8.xml
@@ -8,7 +8,7 @@
                         ܡܝ̈ܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -64,7 +64,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/8</idno>
                 <availability>
                     <p/>
@@ -84,11 +84,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/80.xml
+++ b/data/tei/80.xml
@@ -8,7 +8,7 @@
                         ܘܙܝܙ̈ܢܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/80</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/81.xml
+++ b/data/tei/81.xml
@@ -8,7 +8,7 @@
                         ܕܲܨܠܝܼܒܼܵܐ ܩܲܕܿܝܼܫܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/81</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/82.xml
+++ b/data/tei/82.xml
@@ -8,7 +8,7 @@
                     ܕܲܢܚܵܫܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/82</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/83.xml
+++ b/data/tei/83.xml
@@ -8,7 +8,7 @@
                         ܡܫܝܼܚܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/83</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/84.xml
+++ b/data/tei/84.xml
@@ -8,7 +8,7 @@
                     ܙܲܒܼܢܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/84</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/85.xml
+++ b/data/tei/85.xml
@@ -8,7 +8,7 @@
                         ܐܹܫܲܥܝܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/85</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/86.xml
+++ b/data/tei/86.xml
@@ -8,7 +8,7 @@
                         ܟܵܗܢܘܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/86</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/87.xml
+++ b/data/tei/87.xml
@@ -8,7 +8,7 @@
                     ܩܘܼܕܵܫܥܹܕܿܬܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/87</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/88.xml
+++ b/data/tei/88.xml
@@ -8,7 +8,7 @@
                         ܕܐܲܠܵܗܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/88</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/89.xml
+++ b/data/tei/89.xml
@@ -8,7 +8,7 @@
                         ܥܲܠ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/89</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/9.xml
+++ b/data/tei/9.xml
@@ -7,7 +7,7 @@
                     On Humility - <foreign xml:lang="syr">ܬܚܘܝܬܐ ܕܡܟܝܟܘܬܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8501">The
                     Demonstrations</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/10">Aphrahat</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -63,7 +63,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/9</idno>
                 <availability>
                     <p/>
@@ -83,11 +83,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/90.xml
+++ b/data/tei/90.xml
@@ -7,7 +7,7 @@
                     (Memra 63) - <foreign xml:lang="syr">ܥܲܠ ܬܘܼܩܵܢܵܐ ܕܲܒܼܪܝܼܬܼܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/90</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/91.xml
+++ b/data/tei/91.xml
@@ -7,7 +7,7 @@
                     (Memra 64) - <foreign xml:lang="syr">ܥܲܠ ܬܘܼܩܵܢܵܐ ܕܡܲܠܲܐܟܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/91</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/92.xml
+++ b/data/tei/92.xml
@@ -7,7 +7,7 @@
                     (Memra 65) - <foreign xml:lang="syr">ܥܲܠ ܕܘܼܒܵܪܵܐ ܕܡܲܠܲܐܟܹ̈ܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/92</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/93.xml
+++ b/data/tei/93.xml
@@ -8,7 +8,7 @@
                     </foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/93</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/94.xml
+++ b/data/tei/94.xml
@@ -8,7 +8,7 @@
                         ܠܲܒܢܵܘ̈ܗܝ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/94</idno>
                 <availability>
                     <p/>
@@ -91,11 +91,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/95.xml
+++ b/data/tei/95.xml
@@ -9,7 +9,7 @@
                 <!-- Insert titles and add work # -->
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -60,7 +60,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/95</idno>
                 <availability>
                     <p/>
@@ -92,11 +92,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/96.xml
+++ b/data/tei/96.xml
@@ -7,7 +7,7 @@
                     - <foreign xml:lang="syr">ܥܲܠ ܐܝܼܘܿܒܼ ܙܲܕܿܝܼܩܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/96</idno>
                 <availability>
                     <p/>
@@ -95,11 +95,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/97.xml
+++ b/data/tei/97.xml
@@ -8,7 +8,7 @@
                     ܐܲܚܵܘ̈ܗܝ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/97</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/98.xml
+++ b/data/tei/98.xml
@@ -7,7 +7,7 @@
                     (Memra 71) - <foreign xml:lang="syr">ܥܲܠ ܛܵܘܦܵܢܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -58,7 +58,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/98</idno>
                 <availability>
                     <p/>
@@ -90,11 +90,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tei/99.xml
+++ b/data/tei/99.xml
@@ -8,7 +8,7 @@
                         ܕܲܚܙܵܐ</foreign></title>
                 <title xml:lang="en" level="s" ref="http://syriaca.org/work/8528">The Homilies of
                     Mar Narsai</title>
-                <title level="s">The Oxford-BYU Syriac Corpus</title>
+                <title level="s">Digital Syriac Corpus</title>
                 <author ref="http://syriaca.org/person/650">Narsai</author>
                 <sponsor>University of Oxford</sponsor>
                 <sponsor>Brigham Young University</sponsor>
@@ -59,7 +59,7 @@
                     <placeName>Jean and Alexander Heard Library System, Vanderbilt University,
                         Nashville, Tennessee, USA</placeName>
                 </distributor>
-                <authority>The Oxford-BYU Syriac Corpus</authority>
+                <authority>Digital Syriac Corpus</authority>
                 <idno type="URI">https://syriaccorpus.org/99</idno>
                 <availability>
                     <p/>
@@ -96,11 +96,8 @@
         </fileDesc>
         <encodingDesc>
             <editorialDecl>
-                <p>The Oxford-BYU Syriac Corpus is a joint project of the University of Oxford and
-                    Brigham Young University in collaboration with Vanderbilt University and the
-                    Initiative for Digital Humanities, Media, and Culture at Texas A&amp;M
-                    University.</p>
-                <!-- Look at editorialDecl desription in P5 for labels (https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-editorialDecl.html) and use as necessary to describe the corpus/text in question -->
+                <p>Digital Syriac Corpus is collaboration of University of Oxford, Brigham Young University, Vanderbilt University, and the Center of Digital Humanities Research (CoDHR) at Texas A&amp;M University. </p>
+                
             </editorialDecl>
         </encodingDesc>
         <profileDesc>


### PR DESCRIPTION
Changed name from Oxford-BYU Syriac Corpus to Digital Syriac Corpus in
three places in the code across the corpus:
1) title
2) authority
3) editorialDecl (updated the language here to match the footer text)